### PR TITLE
chore: yoloface warning 로그 제거

### DIFF
--- a/app/model/yoloface/utils/general.py
+++ b/app/model/yoloface/utils/general.py
@@ -88,8 +88,8 @@ def check_requirements(file='requirements.txt'):
 def check_img_size(img_size, s=32):
     # Verify img_size is a multiple of stride s
     new_size = make_divisible(img_size, int(s))  # ceil gs-multiple
-    if new_size != img_size:
-        print('WARNING: --img-size %g must be multiple of max stride %g, updating to %g' % (img_size, s, new_size))
+    # if new_size != img_size:
+    #     print('WARNING: --img-size %g must be multiple of max stride %g, updating to %g' % (img_size, s, new_size))
     return new_size
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25

## 📝작업 내용

> 기존에 people 요청 처리 시, 결과 feature map이 정수가 되지 않아 경고를 발생시켰습니다.
그러나 경고 이후 내부적으로 조정이 이루어지어 요청 처리 자체에는 문제가 없었습니다.
이에 사진 크기 전처리로 요청 시간을 늘리는 것보다
사진 크기 처리는 내부에 최적화된 로직에 맞기도 경고 메시지를 생략하는 방식을 선정했습니다.
이는 서비스에 관련성 없는 로그를 최소화하기 위함입니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
