### PR TITLE
fix: image_features 중복 로딩 수정

### DIFF
--- a/app/api/controllers/album_category_controller.py
+++ b/app/api/controllers/album_category_controller.py
@@ -21,9 +21,7 @@ def categorize_controller(req: ImageRequest, request: Request):
             content={"message": "embedding_required", "data": missing_keys},
         )
 
-    image_features = torch.stack([
-        get_cached_embedding(image_name) for image_name in image_names
-    ])
+    image_features = torch.stack(image_features)
     image_features /= image_features.norm(dim=-1, keepdim=True)
 
     categorized = categorize_images(

--- a/app/api/controllers/album_duplicate_controller.py
+++ b/app/api/controllers/album_duplicate_controller.py
@@ -17,8 +17,6 @@ def duplicate_controller(req: ImageRequest):
             content={"message": "embedding_required", "data": missing_keys},
         )
 
-    image_features = torch.stack([
-        get_cached_embedding(image_name) for image_name in image_names
-    ])
+    image_features = torch.stack(image_features)
     data = find_duplicate_groups(image_features, image_names)
     return {"message": "success", "data": data}

--- a/app/api/controllers/album_quality_controller.py
+++ b/app/api/controllers/album_quality_controller.py
@@ -18,9 +18,7 @@ def quality_controller(req: ImageRequest, request: Request):
             content={"message": "embedding_required", "data": missing_keys},
         )
 
-    image_features = torch.stack([
-        get_cached_embedding(image_name) for image_name in image_names
-    ])
+    image_features = torch.stack(image_features)
     image_features /= image_features.norm(dim=-1, keepdim=True)
 
     result = get_low_quality_images(image_names, image_features)


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #44 

## 📝작업 내용

> ### 📌 작업 개요
임베딩을 사용하는 모든 controller에서 get_cached_embedding을 중복해서 호출하는 문제

### 📋 작업 상세
- image_features는 get_cached_embeddings_parallel로만 불러오도록 수정

