### PR TITLE
Feat/#47

### DIFF
--- a/app/api/controllers/album_people_controller.py
+++ b/app/api/controllers/album_people_controller.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import Request
 
 from app.schemas.album_schema import ImageRequest
@@ -6,7 +8,7 @@ from app.utils.logging_decorator import log_exception
 
 
 @log_exception
-async def people_controller(req: ImageRequest, request: Request):
+async def people_controller(req: ImageRequest, request: Request) -> dict[str, Any]:
     """
     이미지 파일들의 이름을 받아 동일 인물 기준으로 클러스터링합니다.
 

--- a/app/api/endpoints/album_health_router.py
+++ b/app/api/endpoints/album_health_router.py
@@ -9,7 +9,7 @@ router = APIRouter(tags=["health"])
 
 @router.get("", status_code=200)
 @log_flow
-def health_check():
+def health_check() -> dict[str, str]:
     return {
         "status": "ok",
         "message": "ONGI AI Server is healthy",

--- a/app/api/endpoints/album_people_router.py
+++ b/app/api/endpoints/album_people_router.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from fastapi import APIRouter, Request
 
 from app.api.controllers.album_people_controller import people_controller
@@ -9,5 +11,6 @@ router = APIRouter(tags=["people"])
 
 @router.post("", status_code=201)
 @log_flow
-async def people(req: ImageRequest, request: Request):
+async def people(req: ImageRequest, request: Request) -> dict[str, Any]:
+    """동일 인물 얼굴 클러스터링 요청을 people_controller에 전달합니다."""
     return await people_controller(req, request)

--- a/app/service/people.py
+++ b/app/service/people.py
@@ -2,6 +2,9 @@ from collections import defaultdict
 
 import numpy as np
 import torch
+from typing import Any
+from numpy.typing import NDArray
+from PIL import Image
 from sklearn.cluster import DBSCAN
 from sklearn.metrics.pairwise import cosine_distances
 from torch import Tensor
@@ -11,7 +14,7 @@ from app.utils.logging_decorator import log_exception
 device = "cpu"
 
 
-def preprocess(face: np.ndarray) -> np.ndarray:
+def preprocess(face: NDArray[np.uint8]) -> NDArray[np.float32]:
     """
     얼굴 이미지를 ArcFace 입력 형식에 맞게 전처리합니다.
 
@@ -27,12 +30,12 @@ def preprocess(face: np.ndarray) -> np.ndarray:
 
     """
     face = np.transpose(face, (2, 0, 1)).astype(np.float32)
-    return (face - 127.5) / 128.0
+    return ((face - 127.5) / 128.0).astype(np.float32)
 
 
 @log_exception
 def cluster_faces(
-    images: list, file_names: list[str], arcface_model, yolo_detector
+    images: list[Image.Image], file_names: list[str], arcface_model: Any, yolo_detector: Any
 ) -> list[list[str]]:
     """
     유사한 얼굴을 클러스터링합니다.
@@ -43,7 +46,7 @@ def cluster_faces(
     이후 클러스터의 평균 및 최대 거리 기준으로 신뢰도 있는 결과만 필터링합니다.
 
     Args:
-        images (list): PIL.Image 또는 ndarray 형태의 이미지 리스트.
+        images (list): PIL.Image 형태의 이미지 리스트.
         file_names (list[str]): 각 이미지에 대응하는 파일명 리스트.
         arcface_model: 얼굴 임베딩을 위한 ArcFace 모델.
         yolo_detector: 얼굴 검출 및 정렬을 위한 YOLO 기반 detector 객체.

--- a/app/utils/image_loader.py
+++ b/app/utils/image_loader.py
@@ -46,7 +46,7 @@ class BaseImageLoader(ABC):
 class LocalImageLoader(BaseImageLoader):
     """로컬 파일 시스템에서 이미지를 로드하는 클래스입니다."""
 
-    def __init__(self, image_dir: str = LOCAL_IMG_PATH):
+    def __init__(self, image_dir: str | None = LOCAL_IMG_PATH):
         """
         Args:
             image_dir (str): 이미지가 저장된 로컬 디렉토리 경로

--- a/app/utils/logging_decorator.py
+++ b/app/utils/logging_decorator.py
@@ -1,14 +1,19 @@
 import asyncio
+from collections.abc import Callable
 from functools import wraps
+from typing import ParamSpec, TypeVar
 
 from loguru import logger
 
+P = ParamSpec("P")
+R = TypeVar("R")
 
-def log_exception(func):
+
+def log_exception(func: Callable[P, R]) -> Callable[P, R]:
     """예외 발생 시 자동으로 로깅하는 데코레이터"""
 
     @wraps(func)
-    def sync_wrapper(*args, **kwargs):
+    def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
             return func(*args, **kwargs)
         except Exception as e:
@@ -18,23 +23,23 @@ def log_exception(func):
             raise
 
     @wraps(func)
-    async def async_wrapper(*args, **kwargs):
+    async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         try:
-            return await func(*args, **kwargs)
+            return await func(*args, **kwargs)  # type: ignore
         except Exception as e:
             logger.opt(depth=1).exception(
                 f"{func.__name__} 함수 예외 발생: {e}"
             )
             raise
 
-    return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
+    return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper  # type: ignore
 
 
-def log_flow(func):
+def log_flow(func: Callable[P, R]) -> Callable[P, R]:
     """함수 플로우 로깅 데코레이터"""
 
     @wraps(func)
-    def sync_wrapper(*args, **kwargs):
+    def sync_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         logger.opt(depth=2).info(f"{func.__name__} 함수 시작")
 
         try:
@@ -49,13 +54,13 @@ def log_flow(func):
             raise
 
     @wraps(func)
-    async def async_wrapper(*args, **kwargs):
+    async def async_wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         logger.opt(depth=2).info(f"{func.__name__} 함수 시작")
 
         try:
-            result = await func(*args, **kwargs)
+            result = await func(*args, **kwargs)  # type: ignore
             logger.opt(depth=2).info(f"{func.__name__} 함수 성공")
-            return result
+            return result  # type: ignore
 
         except Exception as e:
             logger.opt(depth=2).exception(
@@ -63,4 +68,4 @@ def log_flow(func):
             )
             raise
 
-    return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
+    return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper  # type: ignore


### PR DESCRIPTION
## #️⃣연관된 이슈

> #47

## 📝작업 내용

> mypy와 관련된 컨벤션 작업을 했습니다.
> 로깅 데코레이터는 타입 체킹을 비활성화했습니다.
상황: 
로깅은 동기와 비동기 타입 분리가 일어나는데 함수 타입은 런타임으로 정해지는 부분이라
정적 타입 분석기인 mypy로 타입 체킹하는데에는 무리가 있습니다. 
mypy에 타입 체킹 ignore한 이유: 
로깅이 런타임에 동작하는데에는 무리가 없고 타입 힌팅 자체도 핵심 비지니스 로직의
타입 체크가 목적입니다. 로깅에서 타입 체킹을 한 이유도 mypy 상 '불필요한' 타입 경고를 
피하기 위함이었으므로 간단히 # type: ignore하여 불필요한 타입 체킹을 막았습니다.

> 로직 상, 타입 힌팅이 빠져있던 부분 보충했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
