### PR TITLE
Feat/#55

### DIFF
--- a/app/api/controllers/album_category_controller.py
+++ b/app/api/controllers/album_category_controller.py
@@ -7,10 +7,10 @@ from fastapi.responses import JSONResponse
 from app.core.cache import get_cached_embeddings_parallel
 from app.schemas.album_schema import ImageCategoryGroup, ImageRequest
 from app.service.category import categorize_images
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 async def categorize_controller(req: ImageRequest, request: Request):
     # TODO: text_features를 불러오는 부분은 app.state에 저장해놓도록 수정
     data = torch.load("app/model/category_features.pt", weights_only=True)

--- a/app/api/controllers/album_duplicate_controller.py
+++ b/app/api/controllers/album_duplicate_controller.py
@@ -7,10 +7,10 @@ from fastapi.responses import JSONResponse
 from app.core.cache import get_cached_embeddings_parallel
 from app.schemas.album_schema import ImageRequest
 from app.service.duplicate import find_duplicate_groups
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 async def duplicate_controller(req: ImageRequest, request: Request):
     loop = request.app.state.loop
 

--- a/app/api/controllers/album_embedding_controller.py
+++ b/app/api/controllers/album_embedding_controller.py
@@ -4,10 +4,10 @@ from fastapi import Request
 
 from app.schemas.album_schema import ImageRequest
 from app.service.embedding import embed_images  # service import
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 async def embed_controller(req: ImageRequest, request: Request):
     filenames = req.images
 

--- a/app/api/controllers/album_people_controller.py
+++ b/app/api/controllers/album_people_controller.py
@@ -5,10 +5,10 @@ from fastapi import Request
 
 from app.schemas.album_schema import ImageRequest
 from app.service.people import cluster_faces
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 async def people_controller(req: ImageRequest, request: Request) -> dict[str, Any]:
     """
     이미지 파일들의 이름을 받아 동일 인물 기준으로 클러스터링합니다.

--- a/app/api/controllers/album_quality_controller.py
+++ b/app/api/controllers/album_quality_controller.py
@@ -7,10 +7,10 @@ from fastapi.responses import JSONResponse
 from app.core.cache import get_cached_embeddings_parallel
 from app.schemas.album_schema import ImageRequest
 from app.service.quality import get_low_quality_images
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 async def quality_controller(req: ImageRequest, request: Request):
     loop = request.app.state.loop
 

--- a/app/api/controllers/album_score_controller.py
+++ b/app/api/controllers/album_score_controller.py
@@ -8,10 +8,10 @@ from fastapi.responses import JSONResponse
 from app.core.cache import get_cached_embeddings_parallel
 from app.schemas.album_schema import CategoryScoreRequest
 from app.service.highlight import score_each_category
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 async def highlight_scoring_controller(req: CategoryScoreRequest, request: Request):
     categories = req.categories
     all_images = list(

--- a/app/core/logger.py
+++ b/app/core/logger.py
@@ -5,8 +5,9 @@ from loguru import logger
 logger.remove()
 logger.add(
     sys.stderr,
-    format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level}</level> | <cyan>{name}</cyan>:<cyan>{line}</cyan> - <level>{message</level>}",
+    format="<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message</level>}",
     level="INFO",
-    backtrace=True,
+    backtrace=False,
+    diagnose=False,
     colorize=True,
 )

--- a/app/service/category.py
+++ b/app/service/category.py
@@ -2,10 +2,9 @@ from collections import Counter, defaultdict
 
 import torch
 
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
 def compute_similarity(
     image_features: torch.Tensor, text_features: torch.Tensor, topk: int
 ):
@@ -47,6 +46,7 @@ def group_images_by_category(filtered_results, top_tags):
     return dict(grouped)
 
 
+@log_flow
 def categorize_images(
     image_features: torch.Tensor,
     image_names: list[str],

--- a/app/service/duplicate.py
+++ b/app/service/duplicate.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 import torch
 from sklearn.cluster import DBSCAN
 
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 def find_duplicate_groups(
     image_features: torch.Tensor,
     image_names: list[str],

--- a/app/service/embedding.py
+++ b/app/service/embedding.py
@@ -1,10 +1,10 @@
 import torch
 
 from app.core.cache import set_cached_embedding
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 def embed_images(
     model, preprocess, images, filenames, batch_size=16, device="cpu"
 ):

--- a/app/service/highlight.py
+++ b/app/service/highlight.py
@@ -1,8 +1,8 @@
 import torch
 
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
-@log_exception
+@log_flow
 def score_each_category(categories, embedding_map, regressor):
     data = []
     for category in categories:
@@ -16,7 +16,7 @@ def score_each_category(categories, embedding_map, regressor):
         data.append({"category": category.category, "images": scores})
     return data
 
-@log_exception
+@log_flow
 def estimate_highlight_score(
     image_features: torch.Tensor,
     image_names: list[str],

--- a/app/service/people.py
+++ b/app/service/people.py
@@ -9,7 +9,7 @@ from sklearn.cluster import DBSCAN
 from sklearn.metrics.pairwise import cosine_distances
 from torch import Tensor
 
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 device = "cpu"
 
@@ -33,7 +33,7 @@ def preprocess(face: NDArray[np.uint8]) -> NDArray[np.float32]:
     return ((face - 127.5) / 128.0).astype(np.float32)
 
 
-@log_exception
+@log_flow
 def cluster_faces(
     images: list[Image.Image], file_names: list[str], arcface_model: Any, yolo_detector: Any
 ) -> list[list[str]]:

--- a/app/service/quality.py
+++ b/app/service/quality.py
@@ -1,10 +1,10 @@
 import torch
 import torch.nn.functional as F
 
-from app.utils.logging_decorator import log_exception
+from app.utils.logging_decorator import log_exception, log_flow
 
 
-@log_exception
+@log_flow
 def compute_pairwise_score(image_features, text_pair):
     """
     이미지 임베딩과 두 개의 텍스트 임베딩 쌍(positive, negative)에 대해 softmax를 통해 positive 점수를 계산합니다.
@@ -22,7 +22,7 @@ def compute_pairwise_score(image_features, text_pair):
     return probs[:, 0]  # positive 클래스의 확률 반환
 
 
-@log_exception
+@log_flow
 def get_field_scores(
     image_features: torch.Tensor,
     text_features: torch.Tensor,

--- a/app/utils/logging_decorator.py
+++ b/app/utils/logging_decorator.py
@@ -17,7 +17,7 @@ def log_exception(func: Callable[P, R]) -> Callable[P, R]:
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            logger.opt(depth=1).exception(
+            logger.opt(depth=1).error(
                 f"{func.__name__} 함수 예외 발생: {e}"
             )
             raise
@@ -27,7 +27,7 @@ def log_exception(func: Callable[P, R]) -> Callable[P, R]:
         try:
             return await func(*args, **kwargs)  # type: ignore
         except Exception as e:
-            logger.opt(depth=1).exception(
+            logger.opt(depth=1).error(
                 f"{func.__name__} 함수 예외 발생: {e}"
             )
             raise
@@ -48,7 +48,7 @@ def log_flow(func: Callable[P, R]) -> Callable[P, R]:
             return result
 
         except Exception as e:
-            logger.opt(depth=2).exception(
+            logger.opt(depth=2).error(
                 f"{func.__name__} 함수 예외 발생: {e}"
             )
             raise
@@ -63,7 +63,7 @@ def log_flow(func: Callable[P, R]) -> Callable[P, R]:
             return result  # type: ignore
 
         except Exception as e:
-            logger.opt(depth=2).exception(
+            logger.opt(depth=2).error(
                 f"{func.__name__} 함수 예외 발생: {e}"
             )
             raise


### PR DESCRIPTION
## #️⃣연관된 이슈

> #55

## 📝작업 내용
> 기존에 라우터에만 log_flow를 붙였던 것을 컨트롤러와 서비스까리 log_exception -> log_flow로 수정했습니다. (이유: 초기 개발 단계에서 자세한 코드 흐름을 확인하는게 더 도움이 될 것. 다른 파트 분들이 로그 확인하기에도 더 용이)
> 기존에 세부 변수까지 로깅 뜨던 것을 exception -> error 변환으로 단순화시켰습니다. (이유: 너무 길고 복잡한 로깅으로 인해 로그 체크가 오히려 더 어려움. error만으로도 에러 백트레킹에는 충분하다 판단)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/adb0f748-4d85-4fde-94e8-e0bd0fc6a359)
로깅 시, 모듈까지 확인되던 것을 모듈:함수까지 뜨도록 수정했습니다.
![image](https://github.com/user-attachments/assets/631d15be-731d-4d07-a387-b7cf3c2c4fea)
에러 발생 시, 백트레킹에 과도하게 복잡한 로그가 뜨던 것 개선했습니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
