### PR TITLE
Refactor/#93

### DIFF
--- a/app/api/controllers/album_quality_controller.py
+++ b/app/api/controllers/album_quality_controller.py
@@ -1,14 +1,11 @@
 import logging, asyncio
-from functools import partial
-from typing import List, Tuple, Any
+import asyncio
 
-import torch
 from fastapi import Request
 from fastapi.responses import JSONResponse
 
-from app.core.cache import get_cached_embeddings_parallel
 from app.schemas.album_schema import ImageRequest
-from app.service.quality import get_low_quality_images, laplacian_filter
+from app.service.quality import get_clip_low_quality_images, get_laplacian_low_quality_images
 from app.utils.logging_decorator import log_exception, log_flow
 
 logger = logging.getLogger(__name__)
@@ -33,60 +30,32 @@ async def quality_controller(req: ImageRequest, request: Request) -> JSONRespons
         extra={"total_images": len(req.images)},
     )
 
-    loop = request.app.state.loop
     image_refs = req.images
-    # TODO: 라플라시안 필터와 CLIP 필터를 병렬로 실행할 수 있도록 개선
-    # 1. 이미지 로드
     image_loader = request.app.state.image_loader
-    images = await image_loader.load_images(image_refs, 'GRAY')
+    text_features = request.app.state.quality_text_features
+    fields = request.app.state.quality_fields
     
-    logger.debug(
-        "이미지 로드 완료",
-        extra={"loaded_images": len(images)},
-    )
+    laplacian_task = asyncio.create_task(get_laplacian_low_quality_images(image_refs, image_loader, THRESHOLD))
+    clip_task = asyncio.create_task(get_clip_low_quality_images(image_refs, text_features, fields))
     
-    # 2. 라플라시안 기반, 저품질 이미지 필터링
-    laplacian_filtered = [image_ref for image_ref, image in zip(image_refs, images) if laplacian_filter(image, THRESHOLD)]
+    await asyncio.wait([clip_task, laplacian_task], return_when=asyncio.FIRST_COMPLETED)
+    
+    clip_low_images, missing_keys = await clip_task
 
-    # 1. 이미지 임베딩 로드
-    embed_load_func = partial(
-        get_cached_embeddings_parallel,
-        image_refs,
-    )
-    image_features, missing_keys = await loop.run_in_executor(
-        None,
-        embed_load_func,
-    )
-
-    # 2. 임베딩이 없는 이미지 처리
     if missing_keys:
-        logger.warning(
-            "일부 이미지의 임베딩이 없음",
-            extra={"missing_count": len(missing_keys)},
-        )
+        laplacian_task.cancel()
+        try:
+            await laplacian_task
+        except asyncio.CancelledError:
+            logger.debug("laplacian_task cancelled")
         return JSONResponse(
             status_code=428,
             content={"message": "embedding_required", "data": missing_keys},
         )
-
-    # 3. 이미지 임베딩 정규화
-    image_features = torch.stack(image_features)
-    image_features /= image_features.norm(dim=-1, keepdim=True)
-    
-    # 4. 저품질 이미지 검색
-    text_features = request.app.state.quality_text_features
-    fields = request.app.state.quality_fields
-
-    task_func = partial(
-        get_low_quality_images,
-        image_refs,
-        image_features,
-        text_features,
-        fields,
-    )
-    
-    clip_filtered = await loop.run_in_executor(None, task_func)
-    result = list(set(laplacian_filtered) | set(clip_filtered))
+            
+    laplacian_low_images = await laplacian_task
+        
+    result = list(set(laplacian_low_images) | set(clip_low_images))
 
     logger.info(
         "저품질 이미지 검색 완료",

--- a/app/service/quality.py
+++ b/app/service/quality.py
@@ -258,3 +258,21 @@ def laplacian_filter(
     resized_image = resize_for_laplacian(image, target_long_side)
     laplacian_var = cv2.Laplacian(resized_image, cv2.CV_64F).var()
     return laplacian_var < threshold
+
+@log_exception
+async def get_laplacian_low_quality_images(image_refs: List[str], image_loader, threshold: float = 80.0) -> List[str]:
+    """
+    이미지 목록에서 Laplacian 필터를 사용하여 저품질 이미지를 검색합니다.
+
+    Args:
+        image_refs (List[str]): 이미지 파일명 목록
+        image_loader: 이미지 로더 객체
+        threshold (float): Laplacian 임계값 (default: 80.0)
+
+    Returns:
+        List[str]: 저품질 이미지 파일명 목록
+    """
+    images = await image_loader.load_images(image_refs, 'GRAY')
+    laplacian_low_quality_images = [image_ref for image_ref, image in zip(image_refs, images) if laplacian_filter(image, threshold)]
+
+    return laplacian_low_quality_images

--- a/app/service/quality.py
+++ b/app/service/quality.py
@@ -1,11 +1,14 @@
 import logging
+from functools import partial
 from typing import Dict, List, Literal, Tuple
 
 import torch
 import torch.nn.functional as F
 import cv2
 import numpy as np
+from fastapi.responses import JSONResponse
 
+from app.core.cache import get_cached_embeddings_parallel
 from app.utils.logging_decorator import log_exception, log_flow
 from app.config.settings import MODEL_NAME
 
@@ -170,9 +173,8 @@ def evaluate_dual_threshold(
 
 
 @log_exception
-def get_low_quality_images(
-    image_names: List[str],
-    image_features: torch.Tensor,
+async def get_clip_low_quality_images(
+    image_refs: List[str],
     text_features: torch.Tensor,
     fields: List[str],
 ) -> List[str]:
@@ -180,8 +182,7 @@ def get_low_quality_images(
     'both'가 아닌 모든 결과를 저품질로 간주하고 해당 이미지 이름을 반환합니다.
 
     Args:
-        image_names: 이미지 이름 리스트
-        image_features: 이미지 임베딩 텐서
+        image_refs: 이미지 이름 리스트
         text_features: 텍스트 임베딩 텐서
         fields: 필드 이름 리스트
 
@@ -191,8 +192,22 @@ def get_low_quality_images(
     """
     logger.info(
         "저품질 이미지 검색 시작",
-        extra={"total_images": len(image_names)},
+        extra={"total_images": len(image_refs)},
     )
+    # 1. 이미지 임베딩 로드
+    image_features, missing_keys = get_cached_embeddings_parallel(image_refs)
+
+    # 2. 임베딩이 없는 이미지 처리
+    if missing_keys:
+        logger.warning(
+            "일부 이미지의 임베딩이 없음",
+            extra={"missing_count": len(missing_keys)},
+        )
+        return image_features, missing_keys
+
+    # 3. 이미지 임베딩 정규화
+    image_features = torch.stack(image_features)
+    image_features /= image_features.norm(dim=-1, keepdim=True)
 
     scores = get_field_scores(image_features, text_features, fields)
     results = evaluate_dual_threshold(
@@ -205,18 +220,18 @@ def get_low_quality_images(
     )
 
     low_quality_images = [
-        name for name, result in zip(image_names, results) if result != "both"
+        name for name, result in zip(image_refs, results) if result != "both"
     ]
 
     logger.info(
         "저품질 이미지 검색 완료",
         extra={
-            "total_images": len(image_names),
+            "total_images": len(image_refs),
             "low_quality_count": len(low_quality_images),
         },
     )
 
-    return low_quality_images
+    return low_quality_images, missing_keys
 
 
 @log_exception


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93 

## 📝작업 내용

> 저품질 사진 필터링 작업의 두가지 로직을 병렬로 실행할 수 있도록 개선

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> asyncio.gather를 사용하려고 했는데, clip_quality 실행 중 임베딩 캐싱 미스가 떴을 때 조기종료를 하기 위해 asyncio.create_task와 asyncio.wait를 사용했습니다.
