### PR TITLE
chore: 도커 빌드, cloub 배포 jobs 분리

### DIFF
--- a/.github/workflows/dev-deploy.yaml
+++ b/.github/workflows/dev-deploy.yaml
@@ -8,7 +8,7 @@ on:
       - closed
 
 jobs:
-  build-only:
+  build-docker:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
@@ -41,6 +41,21 @@ jobs:
         run: |
           docker build -t asia-northeast3-docker.pkg.dev/dev-ongi-3-tier/dev-ongi-ai-repo/ai-cpu:$TAG .
           docker push asia-northeast3-docker.pkg.dev/dev-ongi-3-tier/dev-ongi-ai-repo/ai-cpu:$TAG
+          
+  deploy-cloudbuild:
+    needs: build-docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: dev-ongi-3-tier
 
       - name: Trigger Cloud Build
         run: |


### PR DESCRIPTION
## #️⃣연관된 이슈

> #126

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
도커 빌드와 클라우드 배포 jobs 분리
이를 통해 만약 배포 중 실패 시, 원인 해결하고 
이미 성공한 도커 빌드는 생략, 배포 과정부터 재진행 가능

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
